### PR TITLE
Update dg.rewards to include scroll of hunt as tradable/useable

### DIFF
--- a/skills/dungeoneering-training/dg-rewards.md
+++ b/skills/dungeoneering-training/dg-rewards.md
@@ -15,7 +15,7 @@
 | Scroll of longevity | 800,000 | 2x increase to slayer task quantitites |
 | Scroll of the hunt | 800,000 | Gives 2x higher chances of impling spawns, and +4 higher limit on birdhouses \(4-&gt;8\) |
 
-Note: Only the scroll of farming and the scroll of longevity are tradeable/useable. To enable these scrolls you must `=use` them, you can only do this once. Other scrolls work out of the bank.
+Note: Only the scroll of farming, the scroll of longevity, and the scroll of the hunt are tradeable/useable. To enable these scrolls you must `=use` them, you can only do this once. Other scrolls work out of the bank.
 
 ### Buyable Gear
 


### PR DESCRIPTION
Scroll of the Hunt is tradable/useable, which should be mentioned.
![image](https://user-images.githubusercontent.com/8431944/141536621-276dac90-5c21-4520-b208-0852a3253591.png)

### Description:

Update the DG rewards page to include the scroll of the hunt in the list of tradable/usable scrolls.

### Changes:

- Update the DG rewards page to include the scroll of the hunt in the list of tradable/usable scrolls.

### Confirm Changes
-  [x] I have tested all my changes thoroughly.
