### PR TITLE
Add Dungeoneering Master Cape

### DIFF
--- a/custom-items/equippables.md
+++ b/custom-items/equippables.md
@@ -137,7 +137,7 @@ Additionally, master capes have a perk that is related to the skill that they ar
 | Firemaking   | 2x Wintertodt loot                                                                                           |
 | Woodcutting  | 2x Woodcutting loot                                                                                          |
 | Farming      | 35% seeds saved when equipped (up to 50% with scroll of life), 1/10 per planted seed chance of a mystery box |
-|              |                                                                                                              |
+| Dungeoneering| Improved droprate of Gorajan Shards. (1/500 vs 1/1200 with regular skillcape)                                |
 
 
 


### PR DESCRIPTION
Dungeoneering master cape is not currently listed under master capes.

### Description:

![image](https://user-images.githubusercontent.com/8431944/141537718-6b729337-76d6-4e89-9cca-8d82214552f7.png)
- Adding the dungeoneering master cape along with it's perk.

### Changes:

- Adding the dungeoneering master cape along with it's perk.

### Confirm Changes
-  [x] I have tested all my changes thoroughly.
